### PR TITLE
add dependency-check

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-save-exact = true

--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
   "license": "MIT",
   "scripts": {
     "test": "npm run dependency-check && DEBUG=airtap* mocha --ui qunit --timeout 0 --bail -- test/index.js",
-    "dependency-check": "dependency-check package.json --missing --unused --entry test/index.js"
+    "dependency-check": "dependency-check package.json --missing --unused --entry test/index.js --entry test/unit/*.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
   "license": "MIT",
   "scripts": {
     "test": "npm run dependency-check && DEBUG=airtap* mocha --ui qunit --timeout 0 --bail -- test/index.js",
-    "dependency-check": "dependency-check package.json --missing --unused -i dependency-check -i mocha --entry test/index.js --entry test/integration/*.js --entry test/unit/*.js --entry frameworks/zuul.js --entry frameworks/tape/*.js"
+    "dependency-check": "dependency-check package.json --missing --unused -i dependency-check -i mocha --entry test/index.js --entry test/integration/*.js --entry test/fixtures/*/*.js --entry test/unit/*.js --entry frameworks/zuul.js --entry frameworks/tape/*.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
   "license": "MIT",
   "scripts": {
     "test": "npm run dependency-check && DEBUG=airtap* mocha --ui qunit --timeout 0 --bail -- test/index.js",
-    "dependency-check": "dependency-check package.json --missing --unused --entry test/index.js --entry test/unit/*.js --entry frameworks/zuul.js --entry frameworks/tape/*.js"
+    "dependency-check": "dependency-check package.json --missing --unused -i dependency-check --entry test/index.js --entry test/integration/*.js --entry test/unit/*.js --entry frameworks/zuul.js --entry frameworks/tape/*.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "after": "~0.8.1",
     "browzers": "1.2.0",
     "bulk-require": "0.2.1",
+    "dependency-check": "^2.10.0",
     "mocha": "~1.16.2",
     "phantomjs-prebuilt": "2.1.13",
     "tape": "3.5.0",
@@ -69,6 +70,7 @@
   "author": "Roman Shtylman <shtylman@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "test": "DEBUG=airtap* mocha --ui qunit --timeout 0 --bail -- test/index.js"
+    "test": "npm run dependency-check && DEBUG=airtap* mocha --ui qunit --timeout 0 --bail -- test/index.js",
+    "dependency-check": "dependency-check package.json --missing --unused --entry test/index.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,10 +46,8 @@
     "browzers": "1.2.0",
     "bulk-require": "0.2.1",
     "dependency-check": "^2.10.0",
-    "electron": "^1.8.2",
     "electron-prebuilt": "^1.4.13",
     "mocha": "~1.16.2",
-    "phantomjs": "^2.1.7",
     "phantomjs-prebuilt": "2.1.13",
     "tape": "3.5.0",
     "through2": "0.6.3"
@@ -73,6 +71,6 @@
   "license": "MIT",
   "scripts": {
     "test": "npm run dependency-check && DEBUG=airtap* mocha --ui qunit --timeout 0 --bail -- test/index.js",
-    "dependency-check": "dependency-check package.json --missing --unused -i dependency-check -i mocha -i zuul-ngrok --entry test/index.js --entry test/integration/*.js --entry test/fixtures/*/*.js --entry test/unit/*.js --entry frameworks/zuul.js --entry frameworks/tape/*.js"
+    "dependency-check": "dependency-check package.json --missing --unused -i dependency-check -i mocha -i zuul-ngrok -i phantomjs -i electron --entry test/index.js --entry test/integration/*.js --entry test/fixtures/*/*.js --entry test/unit/*.js --entry frameworks/zuul.js --entry frameworks/tape/*.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
   "license": "MIT",
   "scripts": {
     "test": "npm run dependency-check && DEBUG=airtap* mocha --ui qunit --timeout 0 --bail -- test/index.js",
-    "dependency-check": "dependency-check package.json --missing --unused -i dependency-check --entry test/index.js --entry test/integration/*.js --entry test/unit/*.js --entry frameworks/zuul.js --entry frameworks/tape/*.js"
+    "dependency-check": "dependency-check package.json --missing --unused -i dependency-check -i mocha --entry test/index.js --entry test/integration/*.js --entry test/unit/*.js --entry frameworks/zuul.js --entry frameworks/tape/*.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
   "license": "MIT",
   "scripts": {
     "test": "npm run dependency-check && DEBUG=airtap* mocha --ui qunit --timeout 0 --bail -- test/index.js",
-    "dependency-check": "dependency-check package.json --missing --unused --entry test/index.js --entry test/unit/*.js --entry frameworks/zuul.js"
+    "dependency-check": "dependency-check package.json --missing --unused --entry test/index.js --entry test/unit/*.js --entry frameworks/zuul.js --entry frameworks/tape/*.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,8 +49,7 @@
     "mocha": "~1.16.2",
     "phantomjs-prebuilt": "2.1.13",
     "tape": "3.5.0",
-    "through2": "0.6.3",
-    "zuul-ngrok": "^4.0.0"
+    "through2": "0.6.3"
   },
   "repository": {
     "type": "git",
@@ -71,6 +70,6 @@
   "license": "MIT",
   "scripts": {
     "test": "npm run dependency-check && DEBUG=airtap* mocha --ui qunit --timeout 0 --bail -- test/index.js",
-    "dependency-check": "dependency-check package.json --missing --unused -i dependency-check -i mocha --entry test/index.js --entry test/integration/*.js --entry test/fixtures/*/*.js --entry test/unit/*.js --entry frameworks/zuul.js --entry frameworks/tape/*.js"
+    "dependency-check": "dependency-check package.json --missing --unused -i dependency-check -i mocha -i zuul-ngrok --entry test/index.js --entry test/integration/*.js --entry test/fixtures/*/*.js --entry test/unit/*.js --entry frameworks/zuul.js --entry frameworks/tape/*.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
   "license": "MIT",
   "scripts": {
     "test": "npm run dependency-check && DEBUG=airtap* mocha --ui qunit --timeout 0 --bail -- test/index.js",
-    "dependency-check": "dependency-check package.json --missing --unused --entry test/index.js --entry test/unit/*.js"
+    "dependency-check": "dependency-check package.json --missing --unused --entry test/index.js --entry test/unit/*.js --entry frameworks/zuul.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,10 @@
     "browzers": "1.2.0",
     "bulk-require": "0.2.1",
     "dependency-check": "^2.10.0",
+    "electron": "^1.8.2",
+    "electron-prebuilt": "^1.4.13",
     "mocha": "~1.16.2",
+    "phantomjs": "^2.1.7",
     "phantomjs-prebuilt": "2.1.13",
     "tape": "3.5.0",
     "through2": "0.6.3"


### PR DESCRIPTION
This just moves everything up to a base line.

A few things to think about as we progress:

* When code is removed, e.g. `test/integration/*.js`, then `dependency-check` should fail since it will not find those files -> remove corresponding `--entry` from `package.json`
* I've added `-i` to ignore `mocha` -> remove once we use `tape` for tests
* I've added `-i` to ignore `zuul-ngrok` for now, since I don't know what it's used for -> remove if this dependency should be removed
* `dependency-check` checks both `dependencies` and `devDependencies`, we might want to consider using `--no-dev` to skip checking for `dependency-check` itself (using `-i` to ignore it for now)
* `dependency-check` checks both `--missing` and `--unused`
