### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 
 addons:
   sauce_connect: true
+  hosts:
+    - airtap.local
 
 language: node_js
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 # http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
 sudo: false
 
+addons:
+  sauce_connect: true
+
 language: node_js
 
 node_js:

--- a/bin/airtap
+++ b/bin/airtap
@@ -24,6 +24,7 @@ program
 .option('--phantom-remote-debugger-autorun', 'run tests automatically when --phantom-remote-debugger-port is specified')
 .option('--electron', 'run tests in electron. electron must be installed separately.')
 .option('--sauce-connect [tunnel-identifier]', 'establish a tunnel with sauce connect. Optionally specify the tunnel-identifier')
+.option('--loopback <host name>', 'hostname to use instead of localhost, to accomodate Safari and Edge with Sauce Connect. Must resolve to 127.0.0.1')
 .option('--server <the server script>', 'specify a server script to be run')
 .option('--list-available-browsers', 'list available browsers and versions')
 .option('--browser-name <browser name>', 'specficy the browser name to test an individual browser')
@@ -47,6 +48,7 @@ var config = {
     electron: program.electron,
     prj_dir: process.cwd(),
     sauce_connect: program.sauceConnect,
+    loopback: program.loopback,
     server: program.server,
     concurrency: program.concurrency,
     coverage: program.coverage,

--- a/bin/airtap
+++ b/bin/airtap
@@ -19,13 +19,11 @@ program
 .usage('[options] <files | dir>')
 .option('--ui <testing ui>', 'ui for tests (mocha-bdd, mocha-tdd, qunit, tape)')
 .option('--local [port]', 'port for manual testing in a local browser')
-.option('--tunnel [type]', 'establish a tunnel for outside access. only used when --local is specified')
-.option('--disable-tunnel', 'don\'t establish a tunnel for outside access. override any config in .airtap.yml and .airtaprc')
 .option('--phantom [port]', 'run tests in phantomjs. PhantomJS must be installed separately.')
 .option('--phantom-remote-debugger-port [port]', 'connect phantom to remote debugger')
 .option('--phantom-remote-debugger-autorun', 'run tests automatically when --phantom-remote-debugger-port is specified')
 .option('--electron', 'run tests in electron. electron must be installed separately.')
-.option('--sauce-connect [tunnel-identifier]', 'use saucelabs with sauce connect instead of localtunnel. Optionally specify the tunnel-identifier')
+.option('--sauce-connect [tunnel-identifier]', 'establish a tunnel with sauce connect. Optionally specify the tunnel-identifier')
 .option('--server <the server script>', 'specify a server script to be run')
 .option('--list-available-browsers', 'list available browsers and versions')
 .option('--browser-name <browser name>', 'specficy the browser name to test an individual browser')
@@ -43,7 +41,6 @@ var config = {
     files: program.args,
     local: program.local,
     ui: program.ui,
-    tunnel: program.tunnel,
     phantom: program.phantom,
     phantomRemoteDebuggerPort: program.phantomRemoteDebuggerPort,
     phantomRemoteDebuggerAutorun: program.phantomRemoteDebuggerAutorun,
@@ -144,16 +141,7 @@ if (program.browserName) {
     config = xtend(config, { browsers: [{ name: program.browserName, version: program.browserVersion, platform: program.browserPlatform }] });
 }
 
-if (typeof program.tunnel === 'string') {
-    config.tunnel.type = program.tunnel;
-}
-
 config = readGlobalConfig(config)
-
-// Overwrite tunnel option if --disable-tunnel specified
-if (program.disableTunnel) {
-    config.tunnel = false;
-}
 
 var sauce_username = process.env.SAUCE_USERNAME;
 var sauce_key = process.env.SAUCE_ACCESS_KEY;
@@ -400,9 +388,6 @@ function readYAMLConfig(filename) {
 
 function mergeConfig(config, update) {
     config = xtend(update, config)
-    if (update.tunnel && program.tunnel === true) {
-        config.tunnel = update.tunnel
-    }
     return config
 }
 

--- a/bin/airtap
+++ b/bin/airtap
@@ -25,7 +25,6 @@ program
 .option('--phantom-remote-debugger-port [port]', 'connect phantom to remote debugger')
 .option('--phantom-remote-debugger-autorun', 'run tests automatically when --phantom-remote-debugger-port is specified')
 .option('--electron', 'run tests in electron. electron must be installed separately.')
-.option('--tunnel-host <host url>', 'specify a localtunnel server to use for forwarding')
 .option('--sauce-connect [tunnel-identifier]', 'use saucelabs with sauce connect instead of localtunnel. Optionally specify the tunnel-identifier')
 .option('--server <the server script>', 'specify a server script to be run')
 .option('--list-available-browsers', 'list available browsers and versions')
@@ -50,7 +49,6 @@ var config = {
     phantomRemoteDebuggerAutorun: program.phantomRemoteDebuggerAutorun,
     electron: program.electron,
     prj_dir: process.cwd(),
-    tunnel_host: program.tunnelHost,
     sauce_connect: program.sauceConnect,
     server: program.server,
     concurrency: program.concurrency,

--- a/lib/SauceBrowser.js
+++ b/lib/SauceBrowser.js
@@ -17,7 +17,6 @@ function SauceBrowser(conf, opt) {
     var self = this;
     self._conf = conf;
     self._opt = opt;
-    self._opt.tunnel = (opt.sauce_connect) ? false : (self._opt.tunnel || true);
     self.stats = {
         passed: 0,
         failed: 0

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -21,6 +21,7 @@ function setup_test_instance(opt, cb) {
     function setup(_support_server) {
         support_server = _support_server;
         var config = opt;
+        var loopback = config.loopback || 'localhost';
         var control_port = opt.control_port;
 
         var support_port = undefined;
@@ -47,16 +48,21 @@ function setup_test_instance(opt, cb) {
         bouncer.on('request', on_request(proxy.web));
         bouncer.on('upgrade', on_request(proxy.ws));
 
+        function local_url (port, path) {
+          var base = 'http://' + loopback + ':' + port;
+          return path ? base + path : base;
+        }
+
         function on_request(bounce) {
             return function(req, res) {
                 var args = [].slice.call(arguments);
                 if (is_control_req(req)) {
-                    args.push({ target: 'http://localhost:' + control_port });
+                    args.push({ target: local_url(control_port) });
                     bounce.apply(proxy, args);
                     return;
                 }
 
-                args.push({ target: 'http://localhost:' + support_port }, on_support_server_proxy_done);
+                args.push({ target: local_url(support_port) }, on_support_server_proxy_done);
                 bounce.apply(proxy, args);
             };
         }
@@ -84,7 +90,7 @@ function setup_test_instance(opt, cb) {
         function bouncer_active() {
             var app_port = bouncer.address().port;
             debug('bouncer active on port %d', app_port);
-            cb(null, 'http://localhost:' + app_port + '/__zuul');
+            cb(null, local_url(app_port, '/__zuul'));
         };
     }
 

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -8,7 +8,6 @@ var user_server = require('./user-server');
 // cb(err, instance)
 // instance.shutdown() terminates the instance
 function setup_test_instance(opt, cb) {
-
     var support_server = undefined;
     var bouncer = undefined;
     var Tunnel;
@@ -18,9 +17,6 @@ function setup_test_instance(opt, cb) {
     } else if (typeof opt.tunnel === 'object' && opt.tunnel.type) {
         Tunnel = require('zuul-' + opt.tunnel.type);
         debug('using zuul-%s to tunnel', opt.tunnel.type);
-    } else {
-        Tunnel = require('zuul-localtunnel');
-        debug('using zuul-localhost to tunnel');
     }
 
     var tunnel = new Tunnel(opt);

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -10,16 +10,6 @@ var user_server = require('./user-server');
 function setup_test_instance(opt, cb) {
     var support_server = undefined;
     var bouncer = undefined;
-    var Tunnel;
-    if (typeof opt.tunnel === 'string') {
-        Tunnel = require('zuul-' + opt.tunnel);
-        debug('using zuul-%s to tunnel', opt.tunnel);
-    } else if (typeof opt.tunnel === 'object' && opt.tunnel.type) {
-        Tunnel = require('zuul-' + opt.tunnel.type);
-        debug('using zuul-%s to tunnel', opt.tunnel.type);
-    }
-
-    var tunnel = new Tunnel(opt);
 
     if (opt.server) {
         user_server(opt.server, setup);
@@ -94,18 +84,12 @@ function setup_test_instance(opt, cb) {
         function bouncer_active() {
             var app_port = bouncer.address().port;
             debug('bouncer active on port %d', app_port);
-
-            if (!config.tunnel) {
-                return cb(null, 'http://localhost:' + app_port + '/__zuul');
-            }
-
-            tunnel.connect(app_port, cb);
+            cb(null, 'http://localhost:' + app_port + '/__zuul');
         };
     }
 
     function shutdown() {
         bouncer.close();
-        tunnel.close();
 
         if (support_server) {
             support_server.process.kill('SIGKILL');

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "after": "~0.8.1",
     "browzers": "1.2.0",
     "bulk-require": "0.2.1",
+    "cross-env": "~5.1.3",
     "dependency-check": "^2.10.0",
     "electron-prebuilt": "^1.4.13",
     "mocha": "~1.16.2",
@@ -70,7 +71,7 @@
   "author": "Roman Shtylman <shtylman@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "test": "npm run dependency-check && DEBUG=airtap* mocha --ui qunit --timeout 0 --bail -- test/index.js",
-    "dependency-check": "dependency-check package.json --missing --unused -i dependency-check -i mocha -i zuul-ngrok -i phantomjs -i electron --entry test/index.js --entry test/integration/*.js --entry test/fixtures/*/*.js --entry test/unit/*.js --entry frameworks/zuul.js --entry frameworks/tape/*.js"
+    "test": "npm run dependency-check && cross-env DEBUG=airtap* mocha --ui qunit --timeout 0 --bail -- test/index.js",
+    "dependency-check": "dependency-check package.json --missing --unused -i dependency-check -i mocha -i zuul-ngrok -i phantomjs -i electron -i cross-env --entry test/index.js --entry test/integration/*.js --entry test/fixtures/*/*.js --entry test/unit/*.js --entry frameworks/zuul.js --entry frameworks/tape/*.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
   "license": "MIT",
   "scripts": {
     "test": "npm run dependency-check && cross-env DEBUG=airtap* mocha --ui qunit --timeout 0 --bail -- test/index.js",
-    "dependency-check": "dependency-check package.json --missing --unused -i dependency-check -i mocha -i zuul-ngrok -i phantomjs -i electron -i cross-env --entry test/index.js --entry test/integration/*.js --entry test/fixtures/*/*.js --entry test/unit/*.js --entry frameworks/zuul.js --entry frameworks/tape/*.js"
+    "dependency-check": "dependency-check package.json --missing --unused -i dependency-check -i mocha -i phantomjs -i electron -i cross-env --entry test/index.js --entry test/integration/*.js --entry test/fixtures/*/*.js --entry test/unit/*.js --entry frameworks/zuul.js --entry frameworks/tape/*.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "after": "~0.8.1",
-    "browzers": "1.2.0",
+    "airtap-browsers": "0.0.1",
     "bulk-require": "0.2.1",
     "cross-env": "~5.1.3",
     "dependency-check": "^2.10.0",

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "watchify": "3.7.0",
     "wd": "0.3.11",
     "xtend": "2.1.2",
-    "yamljs": "0.2.8",
-    "zuul-localtunnel": "1.1.0"
+    "yamljs": "0.2.8"
   },
   "devDependencies": {
     "after": "~0.8.1",

--- a/test/integration/capabilities.js
+++ b/test/integration/capabilities.js
@@ -1,6 +1,7 @@
 var Zuul = require('../../');
 
 var assert = require('assert');
+var auth = require('../auth');
 
 test('capabilities config', function(done) {
     var config = {
@@ -10,7 +11,9 @@ test('capabilities config', function(done) {
                 public: 'private'
             }
         },
-        tunnel: 'ngrok'
+        username: auth.username,
+        key: auth.key,
+        sauce_connect: true
     };
 
     var zuul = Zuul(config);

--- a/test/integration/capabilities.js
+++ b/test/integration/capabilities.js
@@ -13,7 +13,8 @@ test('capabilities config', function(done) {
         },
         username: auth.username,
         key: auth.key,
-        sauce_connect: true
+        sauce_connect: true,
+        loopback: 'airtap.local'
     };
 
     var zuul = Zuul(config);

--- a/test/integration/jamine-phantom.js
+++ b/test/integration/jamine-phantom.js
@@ -11,8 +11,7 @@ test('jasmine - phantom', function(done) {
         prj_dir: __dirname + '/../fixtures/jasmine',
         phantom: true,
         concurrency: 1,
-        files: [__dirname + '/../fixtures/jasmine/test.js'],
-        tunnel: 'ngrok'
+        files: [__dirname + '/../fixtures/jasmine/test.js']
     };
 
     var zuul = Zuul(config);

--- a/test/integration/mocha-qunit-phantom.js
+++ b/test/integration/mocha-qunit-phantom.js
@@ -11,8 +11,7 @@ test('mocha-qunit - phantom', function(done) {
         prj_dir: __dirname + '/../fixtures/mocha-qunit',
         phantom: true,
         concurrency: 1,
-        files: [__dirname + '/../fixtures/mocha-qunit/test.js'],
-        tunnel: 'ngrok'
+        files: [__dirname + '/../fixtures/mocha-qunit/test.js']
     };
     var zuul = Zuul(config);
 

--- a/test/integration/mocha-qunit-sauce.js
+++ b/test/integration/mocha-qunit-sauce.js
@@ -14,7 +14,8 @@ test('mocha-qunit - sauce', function(done) {
         username: auth.username,
         concurrency: 5,
         key: auth.key,
-        sauce_connect: true
+        sauce_connect: true,
+        loopback: 'airtap.local'
     };
 
     var zuul = Zuul(config);

--- a/test/integration/mocha-qunit-sauce.js
+++ b/test/integration/mocha-qunit-sauce.js
@@ -14,7 +14,7 @@ test('mocha-qunit - sauce', function(done) {
         username: auth.username,
         concurrency: 5,
         key: auth.key,
-        tunnel: 'ngrok'
+        sauce_connect: true
     };
 
     var zuul = Zuul(config);

--- a/test/integration/mocha-qunit-sauce.js
+++ b/test/integration/mocha-qunit-sauce.js
@@ -23,7 +23,7 @@ test('mocha-qunit - sauce', function(done) {
         assert.ifError(err);
 
         var flattenBrowser = require('../../lib/flatten_browser');
-        var browsersToTest = require('browzers').pullRequest;
+        var browsersToTest = require('airtap-browsers').pullRequest;
         var browsers = flattenBrowser(browsersToTest, allBrowsers);
         var total = browsers.length;
 

--- a/test/integration/mochabdd-phantom.js
+++ b/test/integration/mochabdd-phantom.js
@@ -11,8 +11,7 @@ test('mocha-bdd - phantom', function(done) {
         prj_dir: __dirname + '/../fixtures/mocha-bdd',
         phantom: true,
         concurrency: 1,
-        files: [__dirname + '/../fixtures/mocha-bdd/test.js'],
-        tunnel: 'ngrok'
+        files: [__dirname + '/../fixtures/mocha-bdd/test.js']
     };
 
     var zuul = Zuul(config);

--- a/test/integration/tape-phantom.js
+++ b/test/integration/tape-phantom.js
@@ -12,8 +12,7 @@ test('tape - phantom', function(done) {
         prj_dir: __dirname + '/../fixtures/tape',
         phantom: true,
         concurrency: 1,
-        files: [__dirname + '/../fixtures/tape/test.js'],
-        tunnel: 'ngrok'
+        files: [__dirname + '/../fixtures/tape/test.js']
     };
 
     var zuul = Zuul(config);


### PR DESCRIPTION
My initial plan was to fix the `ngrok` tunneling, get our tests passing and go from there, but this didn't pan out - see https://github.com/airtap/airtap/issues/4#issuecomment-365752449.

So this PR is more aggressive: it removes `localtunnel` and `ngrok` (closes #6) as well as all tunnel options and setup logic. It uses Sauce Connect instead, with an additional `--loopback` option (closes #14). Also closes #4.

After we remove PhantomJS (#7) (of which the tests now run without any tunneling) and further cleanup the handling of options, we could opt to enable Sauce Connect by default (without needing `--sauce-connect`).