### PR TITLE
tap-parser: update to ~5.4.0 (v6+ with es6 class not working with phantomjs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "stacktrace-js": "~2.0.0",
     "superagent": "~3.8.2",
     "tap-finished": "~0.0.1",
-    "tap-parser": "0.7.0",
+    "tap-parser": "~5.4.0",
     "watchify": "~3.10.0",
     "wd": "~1.5.0",
     "xtend": "~4.0.1",


### PR DESCRIPTION
I failed to get more information, but the only thing that's different from `5.4.0` and above is that the parser was rewritten as an es6 class and I _suspect_ `phantomjs` has problems with this. I have tested the latest version of `tap-parser` in normal browsers and it works like a charm, but for some reason not in `phantomjs`.