### PR TITLE
Remove `osenv`

### DIFF
--- a/bin/airtap.js
+++ b/bin/airtap.js
@@ -5,7 +5,7 @@ var fs = require('fs')
 var colors = require('colors')
 var program = require('commander')
 var yaml = require('yamljs')
-var osenv = require('osenv')
+var os = require('os');
 var findNearestFile = require('find-nearest-file')
 var _ = require('lodash')
 
@@ -345,7 +345,7 @@ function readLocalConfig (config) {
 }
 
 function readGlobalConfig (config) {
-  var filename = findNearestFile('.airtaprc') || path.join(osenv.home(), '.airtaprc')
+  var filename = findNearestFile('.airtaprc') || path.join(os.homedir(), '.airtaprc')
   if (fs.existsSync(filename)) {
     var globalConfig
     try {

--- a/bin/airtap.js
+++ b/bin/airtap.js
@@ -5,7 +5,7 @@ var fs = require('fs')
 var colors = require('colors')
 var program = require('commander')
 var yaml = require('yamljs')
-var os = require('os');
+var os = require('os')
 var findNearestFile = require('find-nearest-file')
 var _ = require('lodash')
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "load-script": "~1.0.0",
     "lodash": "~4.17.5",
     "opener": "~1.4.3",
-    "osenv": "~0.1.5",
     "shell-quote": "~1.6.1",
     "stack-mapper": "~0.2.2",
     "stacktrace-js": "~2.0.0",

--- a/test/auth.js
+++ b/test/auth.js
@@ -1,4 +1,4 @@
-var os = require('os');
+var os = require('os')
 var path = require('path')
 var fs = require('fs')
 var yaml = require('yamljs')

--- a/test/auth.js
+++ b/test/auth.js
@@ -1,10 +1,10 @@
-var osenv = require('osenv')
+var os = require('os');
 var path = require('path')
 var fs = require('fs')
 var yaml = require('yamljs')
 
 // optinal additional config from $HOME/.airtaprc
-var home_config = path.join(osenv.home(), '.airtaprc')
+var home_config = path.join(os.homedir(), '.airtaprc')
 var airtaprc = {}
 if (fs.existsSync(home_config)) {
   airtaprc = yaml.parse(fs.readFileSync(home_config, 'utf-8'))


### PR DESCRIPTION
Noticed that the engine was set to >= 4, so I think we should be fine using `os.homedir()` instead. Tested on Node `4.8.7`.

<img width="682" alt="screen shot 2018-02-21 at 2 30 24 pm" src="https://user-images.githubusercontent.com/14703164/36500989-cf1e6002-1713-11e8-8771-18fea45590c0.png">

Let me know if I missed something 💖

<hr />
Closes #52.