### PR TITLE
Setup email for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,6 @@ node_js:
   - 8
   - 6
   - 4
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,6 @@ node_js:
   - 4
 
 notifications:
-  email: false
+  email:
+    recipients:
+      - airtap.org@gmail.com


### PR DESCRIPTION
It's okay to receive email notifications when a build passes, but it can get a little annoying to see these emails, especially if the build is failing for unknown reasons.

This is just a sane default to avoid such problems. Close if deemed unnecessary. 😅