### PR TITLE
Export coverage

### DIFF
--- a/bin/airtap.js
+++ b/bin/airtap.js
@@ -36,7 +36,7 @@ program
   .option('--browser-retries <retries>', 'number of retries allowed when trying to start a cloud browser, default to 6')
   .option('--browser-output-timeout <timeout>', 'how much time to wait between two test results, default to -1 (no timeout)')
   .option('--concurrency <n>', 'specify the number of concurrent browsers to test')
-  .option('--no-coverage', 'disable code coverage analysis with istanbul')
+  .option('--coverage', 'enable code coverage analysis with istanbul')
   .option('--no-instrument', 'disable code coverage instrumentation with istanbul')
   .option('--open', 'open a browser automatically. only used when --local is specified')
   .parse(process.argv)

--- a/bin/airtap.js
+++ b/bin/airtap.js
@@ -37,7 +37,6 @@ program
   .option('--browser-output-timeout <timeout>', 'how much time to wait between two test results, default to -1 (no timeout)')
   .option('--concurrency <n>', 'specify the number of concurrent browsers to test')
   .option('--coverage', 'enable code coverage analysis with istanbul')
-  .option('--no-instrument', 'disable code coverage instrumentation with istanbul')
   .option('--open', 'open a browser automatically. only used when --local is specified')
   .parse(process.argv)
 
@@ -51,7 +50,6 @@ var config = {
   server: program.server,
   concurrency: program.concurrency,
   coverage: program.coverage,
-  instrument: program.instrument,
   open: program.open,
   browser_retries: program.browserRetries && parseInt(program.browserRetries, 10),
   browser_output_timeout: program.browserOutputTimeout && parseInt(program.browserOutputTimeout, 10),

--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -1,13 +1,3 @@
 # Debugging Airtap
 
-**TLDR**: run `airtap --local 9000 --no-coverage test/mytest.js` and open up [http://localhost:9000/airtap](http://localhost:9000/airtap) in your browser of choice.
-
-By default, Airtap can be difficult to debug because your source code is transformed to enable easy code coverage tests. I.e. your code looks like this:
-
-```js
-var __cov_HsIG3o$2IIarpa6am0m3eg = (Function('return this'))();
-if (!__cov_HsIG3o$2IIarpa6am0m3eg.__coverage__) { __cov_HsIG3o$2IIarpa6am0m3eg.__coverage__ = {}; }
-__cov_HsIG3o$2IIarpa6am0m3eg = __cov_HsIG3o$2IIarpa6am0m3eg.__coverage__;
-```
-
-Luckily there is an easy to way to fix this. Simply run Airtap with the `--no-coverage` option, and your code will be kept as normal, readable JavaScript.
+Run `airtap --local 9000 test/mytest.js` and open up [http://localhost:9000/airtap](http://localhost:9000/airtap) in your browser of choice.

--- a/lib/builder-browserify.js
+++ b/lib/builder-browserify.js
@@ -105,7 +105,7 @@ function initBundler (files, config) {
   debug('configuring browserify with provided options: %j', config.browserify)
   configure(bundler, config.browserify)
 
-  if (config.coverage && config.local) {
+  if (config.coverage) {
     debug('using istanbul transform')
     bundler.transform(istanbul({
       defaultIgnore: true

--- a/lib/builder-browserify.js
+++ b/lib/builder-browserify.js
@@ -105,7 +105,7 @@ function initBundler (files, config) {
   debug('configuring browserify with provided options: %j', config.browserify)
   configure(bundler, config.browserify)
 
-  if (config.coverage && config.instrument && config.local) {
+  if (config.coverage && config.local) {
     debug('using istanbul transform')
     bundler.transform(istanbul({
       defaultIgnore: true

--- a/lib/control-app.js
+++ b/lib/control-app.js
@@ -78,7 +78,7 @@ module.exports = function (config, cb) {
   app.use(express.static(process.cwd()))
 
   // TODO disable coverage until we find replacement for istanbul-middleware
-  // if (config.coverage && config.local) {
+  // if (config.coverage) {
   //   // coverage endpoint
   //   app.use('/airtap/coverage', im.createHandler())
   // }

--- a/lib/control-app.js
+++ b/lib/control-app.js
@@ -6,12 +6,13 @@ var compression = require('compression')
 var express = require('express')
 var expstate = require('express-state')
 var browserify = require('browserify')
-// var im = require('istanbul-middleware')
 var watchify = require('watchify')
 var assign = require('lodash').assign
 var humanizeDuration = require('humanize-duration')
 var enableDestroy = require('server-destroy')
+var bodyParser = require('body-parser')
 var debug = require('debug')('airtap:control-app')
+var postCoverage = require('./post-coverage')
 
 var defaultBuilder = '../lib/builder-browserify'
 
@@ -45,6 +46,7 @@ module.exports = function (config, cb) {
 
   var app = express()
   app.use(compression())
+  app.use(bodyParser.json())
 
   expstate.extend(app)
 
@@ -77,11 +79,13 @@ module.exports = function (config, cb) {
   // any user's files
   app.use(express.static(process.cwd()))
 
-  // TODO disable coverage until we find replacement for istanbul-middleware
-  // if (config.coverage) {
-  //   // coverage endpoint
-  //   app.use('/airtap/coverage', im.createHandler())
-  // }
+  if (config.coverage) {
+    app.post('/airtap/coverage/reports', postCoverage({
+      basedir: path.join(projectDir, '.nyc_output'),
+      prefix: 'airtap-',
+      name: config.local ? 'local' : null
+    }))
+  }
 
   var map
   var tape = path.resolve(__dirname, '../client/tape.js')

--- a/lib/post-coverage.js
+++ b/lib/post-coverage.js
@@ -1,0 +1,36 @@
+'use strict'
+
+var path = require('path')
+var fs = require('fs')
+var crypto = require('crypto')
+var mkdirp = require('mkdirp')
+
+module.exports = function middleware (opts) {
+  // TODO: rimraf basedir/* (but just once)
+  var basedir = path.resolve(opts.basedir)
+  var prefix = opts.prefix || ''
+
+  return function (req, res, next) {
+    var coverage = req.body
+
+    if (typeof coverage !== 'object' || Object.keys(coverage).length === 0) {
+      res.status(400)
+      return res.end()
+    }
+
+    var json = JSON.stringify(coverage)
+    var name = opts.name || crypto.createHash('sha1').update(json).digest('hex')
+    var fp = path.join(basedir, prefix + name + '.json')
+
+    mkdirp(basedir, function (err) {
+      if (err) return next(err)
+
+      fs.writeFile(fp, json, function (err) {
+        if (err) return next(err)
+
+        res.status(201)
+        res.end()
+      })
+    })
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/airtap.js",
   "dependencies": {
     "batch": "~0.6.1",
+    "body-parser": "~1.18.3",
     "browserify": "~13.3.0",
     "browserify-istanbul": "~3.0.1",
     "chalk": "^2.3.1",
@@ -23,6 +24,7 @@
     "humanize-duration": "~3.15.0",
     "load-script": "~1.0.0",
     "lodash": "~4.17.5",
+    "mkdirp": "~0.5.1",
     "opener": "~1.4.3",
     "sauce-browsers": "~2.0.0",
     "server-destroy": "~1.0.1",


### PR DESCRIPTION
Closes #162.

This disables coverage by default. If `--coverage` is passed, airtap collects code coverage per browser, written to `.nyc-output/airtap-<hash>.json` in Istanbul 1.0 format. One can generate reports with `nyc report` (nyc takes care of merging files from multiple browsers). In local mode, airtap writes to `.nyc-output/airtap-local.json` (so that no cleanup is necessary between repeated runs, e.g. if you refresh the page).

Usage in CI is `airtap --sauce-connect --loopback airtap.local --coverage test.js`, and if you want, add a Travis hook to post results to coveralls:

```yaml
after_success: npm run coverage
```

```json
"scripts": {
  "coverage": "nyc report --reporter=text-lcov | coveralls"
}
```

Later we should:

- Remove the "Code coverage" tab from the UI (IMO)
- Remove previous files before all tests start (this only matters when running locally and you also run node tests and already have files in `.nyc-output`)
- Make it more generic (not tied to `nyc`)
- Move the middleware to a module
- Support coverage in electron

