### PR TITLE
Fix android 7

### DIFF
--- a/lib/sauce-browser.js
+++ b/lib/sauce-browser.js
@@ -53,6 +53,11 @@ SauceBrowser.prototype._start = function () {
       platform: conf.platform
     }, conf.capabilities)
 
+    // Workaround for https://github.com/airtap/browsers/issues/3
+    if (initOpts.browserName === 'android' && initOpts.version.split('.')[0] === '7') {
+      initOpts.deviceName = 'Android GoogleAPI Emulator'
+    }
+
     // use the SAUCE_APPIUM_VERSION environment variable to specify the
     // Appium version. If not specified the test will run against the
     // default Appium version

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "yamljs": "~0.3.0"
   },
   "devDependencies": {
-    "airtap-browsers": "^0.1.0",
+    "airtap-browsers": "^0.2.0",
     "cross-env": "~5.2.0",
     "dependency-check": "^3.0.0",
     "electron": "^2.0.3",


### PR DESCRIPTION
Closes airtap/browsers#3, using the workaround suggested by @jhiesey in https://github.com/airtap/browsers/issues/3#issuecomment-368732332.