### PR TITLE
Use `buffer@4` for tape client in old IE

### DIFF
--- a/client/buffer.js
+++ b/client/buffer.js
@@ -1,0 +1,7 @@
+if (typeof Uint8Array === 'undefined') {
+  // Use `buffer@4` with object fallback implementation
+  module.exports = require('buffer/')
+} else {
+  // Use faster, more feature-rich `buffer@5`
+  module.exports = require('buffer')
+}

--- a/client/buffer.js
+++ b/client/buffer.js
@@ -1,7 +1,7 @@
 if (typeof Uint8Array === 'undefined') {
   // Use `buffer@4` with object fallback implementation
-  module.exports = require('buffer/')
+  module.exports = require('buffer@4')
 } else {
   // Use faster, more feature-rich `buffer@5`
-  module.exports = require('buffer')
+  module.exports = require('buffer@5')
 }

--- a/client/index.html
+++ b/client/index.html
@@ -23,6 +23,11 @@
     {{#if config.port}}
       ZUUL.port = {{config.port}};
     {{/if}}
+
+    var clientScript = '/airtap/client.js';
+    if (typeof Uint8Array === 'undefined') {
+      clientScript += '?ie=1';
+    }
+    document.write('<script src="' + clientScript + '">\x3c/script>');
   </script>
-  <script src="/airtap/client.js"></script>
 </body>

--- a/lib/control-app.js
+++ b/lib/control-app.js
@@ -6,7 +6,6 @@ var compression = require('compression')
 var express = require('express')
 var expstate = require('express-state')
 var browserify = require('browserify')
-var browserifyBuiltins = require('browserify/lib/builtins')
 var watchify = require('watchify')
 var assign = require('lodash').assign
 var humanizeDuration = require('humanize-duration')
@@ -88,28 +87,31 @@ module.exports = function (config, cb) {
     }))
   }
 
-  var tape = path.join(__dirname, '../client/tape.js')
+  function initBundler () {
+    var tape = path.join(__dirname, '../client/tape.js')
+    var bundler = browserify(tape, opt)
 
-  var map
-  var bundler = browserify(tape, opt)
+    // we use watchify to speed up `.bundle()` calls
+    if (config.watchify) {
+      bundler = watchify(bundler, {
+        ignoreWatch: true
+      })
+    }
 
-  // we use watchify to speed up `.bundle()` calls
-  if (config.watchify) {
-    bundler = watchify(bundler, {
-      ignoreWatch: true
-    })
+    return bundler
   }
 
-  // support IE9+ with runtime feature detection
-  var oldBuffer = require.resolve('buffer/')
-  var newBuffer = browserifyBuiltins.buffer
-  var chooseImplementation = path.join(__dirname, '../client/buffer.js')
-  bundler.require(oldBuffer, { expose: 'buffer@4' })
-  bundler.require(newBuffer, { expose: 'buffer@5' })
-  bundler.require(chooseImplementation, { expose: 'buffer' })
+  var map
+  var bundlerModern = initBundler()
+  var bundlerOldIe = initBundler()
+
+  // Use `buffer@4` in old IE
+  bundlerOldIe.require(require.resolve('buffer/'), { expose: 'buffer' })
 
   router.get('/airtap/client.js', function (req, res, next) {
     res.contentType('application/javascript')
+
+    var bundler = req.query.ie ? bundlerOldIe : bundlerModern
 
     var start = Date.now()
     debug('creating client bundle')
@@ -158,7 +160,8 @@ module.exports = function (config, cb) {
       server.destroy(function (err) {
         build.close()
         if (config.watchify) {
-          bundler.close()
+          bundlerModern.close()
+          bundlerOldIe.close()
         }
         cb(err)
       })

--- a/lib/control-app.js
+++ b/lib/control-app.js
@@ -90,7 +90,7 @@ module.exports = function (config, cb) {
   var map
   var tape = path.resolve(__dirname, '../client/tape.js')
   var bundler = browserify(tape, opt)
-  // support IE9+
+  // support IE9+ with runtime feature detection
   bundler.require(path.resolve(__dirname, '../client/buffer.js'), { expose: 'buffer' })
 
   // we use watchify to speed up `.bundle()` calls

--- a/lib/control-app.js
+++ b/lib/control-app.js
@@ -6,6 +6,7 @@ var compression = require('compression')
 var express = require('express')
 var expstate = require('express-state')
 var browserify = require('browserify')
+var browserifyBuiltins = require('browserify/lib/builtins')
 var watchify = require('watchify')
 var assign = require('lodash').assign
 var humanizeDuration = require('humanize-duration')
@@ -87,11 +88,10 @@ module.exports = function (config, cb) {
     }))
   }
 
+  var tape = path.join(__dirname, '../client/tape.js')
+
   var map
-  var tape = path.resolve(__dirname, '../client/tape.js')
   var bundler = browserify(tape, opt)
-  // support IE9+ with runtime feature detection
-  bundler.require(path.resolve(__dirname, '../client/buffer.js'), { expose: 'buffer' })
 
   // we use watchify to speed up `.bundle()` calls
   if (config.watchify) {
@@ -100,10 +100,19 @@ module.exports = function (config, cb) {
     })
   }
 
+  // support IE9+ with runtime feature detection
+  var oldBuffer = require.resolve('buffer/')
+  var newBuffer = browserifyBuiltins.buffer
+  var chooseImplementation = path.join(__dirname, '../client/buffer.js')
+  bundler.require(oldBuffer, { expose: 'buffer@4' })
+  bundler.require(newBuffer, { expose: 'buffer@5' })
+  bundler.require(chooseImplementation, { expose: 'buffer' })
+
   router.get('/airtap/client.js', function (req, res, next) {
     res.contentType('application/javascript')
 
     var start = Date.now()
+    debug('creating client bundle')
     bundler.bundle(function (err, buf) {
       if (err) {
         return next(err)
@@ -126,6 +135,7 @@ module.exports = function (config, cb) {
   router.get('/airtap/test-bundle.js', function (req, res, next) {
     res.contentType('application/javascript')
 
+    debug('creating test bundle')
     build(function (err, src, srcmap) {
       if (err) {
         return next(err)

--- a/lib/control-app.js
+++ b/lib/control-app.js
@@ -90,6 +90,8 @@ module.exports = function (config, cb) {
   var map
   var tape = path.resolve(__dirname, '../client/tape.js')
   var bundler = browserify(tape, opt)
+  // support IE9+
+  bundler.require(path.resolve(__dirname, '../client/buffer.js'), { expose: 'buffer' })
 
   // we use watchify to speed up `.bundle()` calls
   if (config.watchify) {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "body-parser": "~1.19.0",
     "browserify": "~16.5.0",
     "browserify-istanbul": "~3.0.1",
+    "buffer": "^4.9.2",
     "chalk": "^3.0.0",
     "commander": "~4.0.0",
     "compression": "~1.7.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "license": "MIT",
   "scripts": {
     "test": "standard && hallmark && npm run dependency-check && cross-env DEBUG=airtap* tape test",
-    "dependency-check": "dependency-check package.json --missing --unused -i dependency-check -i cross-env -i standard -i hallmark test/index.js test/fixtures/*/*.js client/*.js",
+    "dependency-check": "dependency-check package.json --missing --unused -i buffer -i buffer@4 -i buffer@5 -i dependency-check -i cross-env -i standard -i hallmark test/index.js test/fixtures/*/*.js client/*.js",
     "hallmark": "hallmark --fix"
   },
   "engines": {


### PR DESCRIPTION
This makes airtap's tape client code work in IE9. If the browser supports
`Uint8Array`, an up-to-date buffer shim is used. Otherwise, the old shim
is used.

This would allow me to upgrade from airtap@1 in `events` and maybe
others :)

I think IE9/IE10 don't need to be like "officially" supported, if it
breaks in the future I can send new PRs until it becomes too much work
(and at that point, `events` will likely have to drop IE9/10 support
anyways).

This only applies to airtap's own code so if old IE support is required
for a project's browser tests, they still need to do the config thing:
```yaml
browserify:
- require: 'buffer/'
  expose: 'buffer'
```