### PR TITLE
Support old IE in airtap client code.

### DIFF
--- a/lib/control-app.js
+++ b/lib/control-app.js
@@ -90,6 +90,8 @@ module.exports = function (config, cb) {
   var map
   var tape = path.resolve(__dirname, '../client/tape.js')
   var bundler = browserify(tape, opt)
+  // Use buffer@4 for airtap's own client code, for old IE compat
+  bundler.require('buffer/', { expose: 'buffer' })
 
   // we use watchify to speed up `.bundle()` calls
   if (config.watchify) {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "body-parser": "~1.19.0",
     "browserify": "~16.5.0",
     "browserify-istanbul": "~3.0.1",
+    "buffer": "^4.9.2",
     "chalk": "^3.0.0",
     "commander": "~4.0.0",
     "compression": "~1.7.1",
@@ -68,7 +69,7 @@
   "license": "MIT",
   "scripts": {
     "test": "standard && hallmark && npm run dependency-check && cross-env DEBUG=airtap* tape test",
-    "dependency-check": "dependency-check package.json --missing --unused -i dependency-check -i cross-env -i standard -i hallmark test/index.js test/fixtures/*/*.js client/*.js",
+    "dependency-check": "dependency-check package.json --missing --unused -i dependency-check -i buffer -i cross-env -i standard -i hallmark test/index.js test/fixtures/*/*.js client/*.js",
     "hallmark": "hallmark --fix"
   },
   "engines": {


### PR DESCRIPTION
The simplest alternative to #273.

This makes airtap's tape client code work in IE9 (and maybe earlier,
`buffer@4` actually works all the way back to IE6 afaik).

This only applies to airtap's own code so if old IE support is required
for a project's browser tests, they still need to do the config thing:
```yaml
browserify:
- require: 'buffer/'
  expose: 'buffer'
```

So projects can still use the new buffer implementation, airtap itself
will just be using the old one for maximum compatibility.