### PR TITLE
Fix README documentation for passing args to browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,7 @@ browsers:
   - name: chromium
     options:
       headless: false
-      launch:
-        args: [--lang=en-US]
+      args: [--lang=en-US]
 ```
 
 For more information on the `browsers` field, see [Configuration](#configuration).


### PR DESCRIPTION
After some trial and error, figured out why I wasn't able to pass arguments to the browsers and updated the README accordingly.