### PR TITLE
Breaking: bump tap-completed from 1 to 2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [10, 12, 14, 16]
+        node: [20, 22]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/bin/airtap.js
+++ b/bin/airtap.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 'use strict'
 
-if (process.version.match(/^v(\d+)\./)[1] < 10) {
-  console.error('airtap: Node 10 or greater is required. `airtap` did not run.')
+if (process.version.match(/^v(\d+)\./)[1] < 20) {
+  console.error('airtap: Node 20 or greater is required. `airtap` did not run.')
   process.exit(0)
 }
 

--- a/lib/browser-session.js
+++ b/lib/browser-session.js
@@ -19,6 +19,7 @@ const kResetIdleTimer = Symbol('kResetIdleTimer')
 const kTimeout = Symbol('kTimeout')
 const kClientErrored = Symbol('kClientErrored')
 const kCwd = Symbol('kCwd')
+const kHandleComplete = Symbol('kHandleComplete')
 
 let seq = 0
 
@@ -50,16 +51,10 @@ class BrowserSession extends Transform {
 
     // Don't care about diagnostics after completion, don't wait.
     this[kParser] = Parser({ wait: 0 })
+    this[kHandleComplete] = this[kHandleComplete].bind(this)
 
     this[kResetIdleTimer]()
-    this[kParser].on('complete', (results) => {
-      this.stats.ok = results.ok
-      this.stats.pass = results.pass
-      this.stats.fail = results.fail
-
-      debug('session %o complete (%s)', this[kTitle], this.stats.ok ? 'ok' : 'not ok')
-      this.emit('complete', this.stats)
-    })
+    this[kParser].on('complete', this[kHandleComplete])
 
     debug('session %o', this[kTitle])
   }
@@ -67,8 +62,21 @@ class BrowserSession extends Transform {
   _destroy (reason, cb) {
     if (reason) debug('destroy %o: %O', this[kTitle], reason)
     clearTimeout(this[kIdleTimer])
+
+    // Destroying also results in a 'complete' event
+    this[kParser].removeListener('complete', this[kHandleComplete])
     this[kParser].destroy()
+
     cb(reason)
+  }
+
+  [kHandleComplete] (results) {
+    this.stats.ok = results.ok
+    this.stats.pass = results.pass
+    this.stats.fail = results.fail
+
+    debug('session %o complete (%s)', this[kTitle], this.stats.ok ? 'ok' : 'not ok')
+    this.emit('complete', this.stats)
   }
 
   [kResetIdleTimer] () {
@@ -109,11 +117,10 @@ class BrowserSession extends Transform {
         this.push(line)
       }
 
-      if (!this[kParser].write(line)) {
-        this[kParser].once('drain', next)
-      } else {
-        next()
-      }
+      // Has no backpressure. Just keep writing.
+      this[kParser].write(line)
+
+      next()
     } else if (msg.type === 'error' && msg.fatal) {
       next(new Error(String(msg.message || 'Client error')))
     } else if (msg.type === 'error') {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "run-parallel-settled": "^1.0.1",
     "server-destroy": "^1.0.1",
     "shell-quote": "^1.7.0",
-    "tap-completed": "^1.0.0",
+    "tap-completed": "^2.0.0",
     "thunky-with-args": "^1.0.0",
     "transient-error": "^1.0.0",
     "uuid": "^8.3.0",
@@ -85,6 +85,6 @@
     "testing"
   ],
   "engines": {
-    "node": ">=10.2"
+    "node": ">=20"
   }
 }


### PR DESCRIPTION
Fixes #334. Breaking because it drops support of Node.js < 20.

Ref: https://github.com/vweevers/tap-completed/releases/tag/v2.0.0